### PR TITLE
add additional commits for cherry-pick to updatecli PR description

### DIFF
--- a/updatecli/updatecli.d/upstream_kine_releases.yml
+++ b/updatecli/updatecli.d/upstream_kine_releases.yml
@@ -93,6 +93,10 @@ actions:
         # Cherry-pick IAM authentication
         git cherry-pick fcf4e5a
 
+        # Cherry-pick release process update for loft-sh org
+        git cherry-pick fe2d5b9
+        git cherry-pick 01c2b02
+
         # Push and tag
         git push origin release-{{ source "latestUpstreamRelease" }}
         git tag v{{ source "latestUpstreamRelease" }}


### PR DESCRIPTION
We need to cherry-pick 2 more commits that are related to updating the release workflow file. These are to correctly GHCR login credentials and to skip pushing built images back to upstream kine.