### PR TITLE
ci(fork): make dockerhub steps optional when docker_token is absent

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,14 +55,6 @@ jobs:
           username: ${{ env.DOCKER_USERNAME }}
           password: ${{ env.DOCKER_TOKEN }}
 
-      # For forks, setup DockerHub login with GHA secrets
-      - name: Login to DockerHub with GHA Secrets
-        if: github.repository_owner != 'k3s-io'
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_TOKEN }}
-      
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
         with:
@@ -93,7 +85,5 @@ jobs:
           target: multi-arch-package
           push: true
           tags: |
-            ${{ secrets.DOCKER_USERNAME }}/kine:latest
-            ${{ secrets.DOCKER_USERNAME }}/kine:${{ github.ref_name }}
             ghcr.io/${{ github.repository_owner }}/kine:latest
             ghcr.io/${{ github.repository_owner }}/kine:${{ github.ref_name }}


### PR DESCRIPTION
The release workflow was failing for `loft-sh/kine` because `DOCKER_TOKEN` is not set as a GitHub Actions secret (we use GHCR, not DockerHub).

## Changes

- Expose `secrets.DOCKER_TOKEN` as a job-level env var (`DOCKER_TOKEN`) so it can be tested in step-level `if:` expressions (the `secrets` context is not available there)
- Guard "Login to DockerHub with GHA Secrets" with `env.DOCKER_TOKEN != ''` so it only runs when the secret is configured
- Remove DockerHub tags from "Build and push (forks)"; GHCR is sufficient for this fork

The same fix is already applied to `release/vcluster/v0.14.16`.